### PR TITLE
fix: 将 zensical 版本要求更新为 >=0.0.36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-zensical>=0.1.0
+zensical>=0.0.36
 pygments>=2.15.0
 pymdown-extensions>=10.0


### PR DESCRIPTION
### 问题
`requirements.txt` 中写了 `zensical>=0.1.0`，但目前 Zensical 最新版本是 0.0.36，导致新用户安装失败。

### 修改内容
- 把 `zensical>=0.1.0` 改为 `zensical>=0.0.36`

### 测试
本地已测试，修改后可正常 `pip install -r requirements.txt`